### PR TITLE
Fixes #2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.whl
 *.tar.gz
 __pycache__
+.DS_Store

--- a/autopytest/autotest.py
+++ b/autopytest/autotest.py
@@ -48,11 +48,13 @@ class Autotest(FileSystemEventHandler):
                 path = Path(event.src_path)
                 test_path_components = ["tests"]
 
-                for component in path.parts:
-                    if re.search(r".py", component):
-                        test_path_components.append(f"test_{component}")
-                    else:
-                        test_path_components.append(component)
+                for component in path.relative_to(Path.cwd()).parts:
+                    if component != "app":
+                        if re.search(r".py", component):
+                            test_path_components.append(f"test_{component}")
+                        else:
+                            test_path_components.append(component)
+                            
                 test_path = "/".join(test_path_components)
                 if Path(test_path).exists() and PytestRunner.run(test_path) == 0:
                     PytestRunner.run(".")


### PR DESCRIPTION
Updated the logic in the autotest module to exclude the 'app' directory from the derived test path. This ensures that when files within the 'app' directory are modified, the corresponding test file's path is correctly identified, and the relevant tests are triggered.